### PR TITLE
Fix SecurityConfig

### DIFF
--- a/src/main/java/org/pac4j/demo/spring/SecurityConfig.java
+++ b/src/main/java/org/pac4j/demo/spring/SecurityConfig.java
@@ -1,9 +1,11 @@
 package org.pac4j.demo.spring;
 
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity.CsrfSpec;
 import org.springframework.security.core.userdetails.MapReactiveUserDetailsService;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -12,23 +14,24 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
 
+@Configuration
 @EnableWebFluxSecurity
 public class SecurityConfig {
 
     @Bean
     public SecurityWebFilterChain securityWebFilterChain(final ServerHttpSecurity http) {
         return  http
-                .csrf().disable()
-                .authorizeExchange()
-                .pathMatchers("/admin/**").hasRole("ADMIN")
-                .pathMatchers("/user/**").authenticated()
-                .anyExchange().permitAll()
-                .and()
-                .formLogin()
-                .loginPage("/login")
-                .and().logout()
-                .requiresLogout(ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, "/logout"))
-                .and().build();
+                .csrf(CsrfSpec::disable)
+                .authorizeExchange(exchanges ->
+                        exchanges.pathMatchers("/admin/**").hasRole("ADMIN")
+                                .pathMatchers("/user/**").authenticated()
+                                .anyExchange().permitAll()
+                )
+                .formLogin(formLogin -> formLogin.loginPage("/login"))
+                .logout(logout ->
+                        logout.requiresLogout(ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, "/logout"))
+                )
+                .build();
     }
 
     @Bean


### PR DESCRIPTION
The example wasn't working correctly for me anymore. No matter which URL I called, I was forwarded to `/login`, but the `admin` and `user` accounts didn't work on it. To fix this situation I needed to add the `@Configuration` annotation. Now the `SecurityWebFilterChain` get's picked up correctly again and the example works.

In addition, this PR removed deprecated API usage.